### PR TITLE
[Fix] Convert Electric Car Values into Percent

### DIFF
--- a/utils/climateDataService.tsx
+++ b/utils/climateDataService.tsx
@@ -84,7 +84,7 @@ export class ClimateDataService {
           NeededEmissionChangePercent: data.neededEmissionChangePercent,
           HitNetZero: data.hitNetZero,
           BudgetRunsOut: data.budgetRunsOut,
-          ElectricCarChangePercent: data.electricCarChangePercent,
+          ElectricCarChangePercent: data.electricCarChangePercent*100,
           ElectricCarChangeYearly: data.electricCarChangeYearly,
           ClimatePlan: climatePlan,
           BicycleMetrePerCapita: data.bicycleMetrePerCapita,


### PR DESCRIPTION
### Background
We realised that the values for electric cars seemed to all be under .1, indicating that the values were not being converted into percent. We are in process of moving the data into the db and rewriting the FE, so this is a temp solution. 

### What changed
Multiplied the value for the electricCarChangePercent by 100 to get the actual percent value. 