### PR TITLE
Quick fix for overlapping navbar & logo

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -41,6 +41,10 @@ const NavigationList = styled.ul`
     height: var(--btn-size);
     align-items: center;
   }
+
+  @media only screen and (max-width: 1055px) {
+    gap: 1.3rem;
+  }
 `
 
 const NavigationItem = styled.li`


### PR DESCRIPTION
Fixed overlapping navbar & logo at specific pixel width when re-sizing in responsive mode. Question is, robust enough lol?

Saw the devices.ts, but felt abit too much adding a specific px there for just this matter. 

Happy to be critiqued!